### PR TITLE
Enable clamping in colorinterp filter

### DIFF
--- a/filters/ColorinterpFilter.cpp
+++ b/filters/ColorinterpFilter.cpp
@@ -37,6 +37,7 @@
 #include <pdal/GDALUtils.hpp>
 #include <pdal/PointView.hpp>
 #include <pdal/util/ProgramArgs.hpp>
+#include <pdal/util/Utils.hpp>
 
 #include <array>
 #include <algorithm>
@@ -111,6 +112,9 @@ void ColorinterpFilter::addArgs(ProgramArgs& args)
         std::numeric_limits<double>::quiet_NaN());
     args.add("maximum", "Maximum value to use for scaling", m_max,
         std::numeric_limits<double>::quiet_NaN());
+    args.add("clamp",
+        "Clamp and color values outside the range [minimum, maximum]",
+        m_clamp, false);
     args.add("ramp", "GDAL-readable color ramp image to use", m_colorramp,
         "pestel_shades");
     args.add("invert", "Invert the ramp direction", m_invertRamp, false);
@@ -269,13 +273,23 @@ bool ColorinterpFilter::processOne(PointRef& point)
 {
     double v = point.getFieldAs<double>(m_interpDim);
 
-    // Don't color points that aren't in the min/max range.
-    if (v < m_min || v >= m_max)
+    if (m_clamp) v = pdal::Utils::clamp(v, m_min, m_max);
+
+    // Don't color points that aren't in the min/max range
+    // unless they've been clamped. Allow v == m_max so that
+    // if the user wants to clamp all values outside m_min
+    // and m_max the values greater than m_max are colored
+    // as expected.
+    if (v < m_min || v > m_max)
         return true;
 
     double factor = (v - m_min) / (m_max - m_min);
     size_t img_width = m_redBand.size();
     size_t position = size_t(std::floor(factor * img_width));
+
+    // Handle the case that v == m_max (position == img_width) by clamping
+    // position to img_width - 1
+    position = pdal::Utils::clamp(position, 0UL, img_width - 1);
 
     if (m_invertRamp)
         position = (img_width - 1) - position;

--- a/filters/ColorinterpFilter.hpp
+++ b/filters/ColorinterpFilter.hpp
@@ -58,6 +58,7 @@ public:
         , m_interpDimString("Z")
         , m_min(0.0)
         , m_max(0.0)
+        , m_clamp(false)
         , m_rampFilename("/vsimem/colorramp.png")
         , m_invertRamp(false)
         , m_stdDevThreshold(0.0)
@@ -81,6 +82,7 @@ private:
     std::string m_interpDimString;
     double m_min;
     double m_max;
+    bool m_clamp;
     std::string m_colorramp;
     std::shared_ptr<gdal::Raster> m_raster;
     std::string m_rampFilename;

--- a/test/unit/filters/ColorinterpFilterTest.cpp
+++ b/test/unit/filters/ColorinterpFilterTest.cpp
@@ -66,9 +66,9 @@ TEST(ColorinterpFilterTest, minmax)
     FauxReader f;
     Options options;
 
-    options.add("count", 100);
+    options.add("count", 101);
     options.add("mode", "ramp");
-    options.add("bounds", "([0,99],[0,99],[0,99])");
+    options.add("bounds", "([0,100],[0,100],[0,100])");
 
     f.setOptions(options);
 
@@ -93,9 +93,14 @@ TEST(ColorinterpFilterTest, minmax)
         int g = point.getFieldAs<int>(Dimension::Id::Green);
         int b = point.getFieldAs<int>(Dimension::Id::Blue);
 
-        if (z != 99)
+        if (z != 100)
+        {
+            std::stringstream ss;
+            ss << "Z = " << z << "; R = " << r;
+            SCOPED_TRACE(ss.str());
             EXPECT_EQ((int)(z / 25) + 1, r);
-        if (z == 99)
+        }
+        if (z == 100)
             EXPECT_EQ(0, r);
         EXPECT_EQ(0, g);
         EXPECT_EQ(0, b);
@@ -207,6 +212,9 @@ void standardTest(Options& coptions, std::function<bool(int, int)> test)
         int g = point.getFieldAs<int>(Dimension::Id::Green);
         int b = point.getFieldAs<int>(Dimension::Id::Blue);
 
+        std::stringstream ss;
+	ss << "Z = " << z << "; R = " << r;
+        SCOPED_TRACE(ss.str());
         EXPECT_TRUE(test(z, r));
         EXPECT_EQ(0, g);
         EXPECT_EQ(0, b);
@@ -232,13 +240,10 @@ TEST(ColorinterpFilterTest, autorange)
 
     auto test = [](int z, int r)
     {
-        if (z < 99)
-            return ((int)(z / 25) + 1 == r);
-        else if (z == 99 && r == 0)
-            return true;
-        return false;
+        return ((int)(z / 25) + 1 == r);
     };
 
+    SCOPED_TRACE("autorange");
     standardTest(coptions, test);
 }
 
@@ -266,6 +271,7 @@ TEST(ColorinterpFilterTest, k)
         return false;
     };
 
+    SCOPED_TRACE("k");
     standardTest(coptions, test);
 }
 
@@ -293,6 +299,8 @@ TEST(ColorinterpFilterTest, mad)
             return true;
         return false;
     };
+
+    SCOPED_TRACE("mad");
     standardTest(coptions, test);
 }
 


### PR DESCRIPTION
Fixes #2729.

Previously values outside a determined range would be left with
default values, potentially providing unexpected results. This
commit adds a `clamp` parameter to a user can explicitly control
whether values outside the given range will be colored.

There apparently an explicit design decision to not include
values equal to the maximum in the coloring. When clamping, this
design then resulted in values that were greated than the max to
still be left uncolored. Since nothing in the available user
documentation explicitly states that the valid range is exclusive
of the maximum value it has been changed to be inclusive.

This required modifying two unit tests which were testing for
maximum values to be excluded from the coloring.

An other approach could have beent to clamp to a value slightly
less than m_max (e.g. m_max - DBL_EPSILON). But this would still
leave a discrepancy between the documentation and the implementation.